### PR TITLE
Option improvements

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -212,6 +212,13 @@ fn handle_fire_with_rpc<T: GethRPCClient>(client: &mut T, vm: &mut VM, block_num
     }
 }
 
+// Note: to turn the below into something that takes an iterator, rather than a vector
+// of &str, we would need to use generics.
+//
+// See https://stackoverflow.com/questions/34969902/
+//  how-to-write-a-rust-function-that-takes-an-iterator
+// Doing this might be slightly more efficient and would avoid the duplicate:
+//   let patch_names: Vec<&str> .... setup in the call
 fn print_valid_patches(patch: &str, patch_names: Vec<&str>) {
     println!("Unsupported patch name: '{}'", patch);
     print!("Supported patch names are: ");

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -209,7 +209,8 @@ fn main() {
             Some("homestead") => Box::new(SeqContextVM::<MainnetHomesteadPatch>::new(context, block)),
             Some("eip150") => Box::new(SeqContextVM::<MainnetEIP150Patch>::new(context, block)),
             Some("eip160") => Box::new(SeqContextVM::<MainnetEIP160Patch>::new(context, block)),
-            _ => panic!("Unsupported patch."),
+            Some(x) => panic!("Unsupported patch name \"{}\"", x),
+            _ => panic!("patch needs a value"),
         }
     } else {
         let transaction = ValidTransaction {
@@ -235,6 +236,7 @@ fn main() {
             Some("homestead") => Box::new(SeqTransactionVM::<MainnetHomesteadPatch>::new(transaction, block)),
             Some("eip150") => Box::new(SeqTransactionVM::<MainnetEIP150Patch>::new(transaction, block)),
             Some("eip160") => Box::new(SeqTransactionVM::<MainnetEIP160Patch>::new(transaction, block)),
+            Some(x) => panic!("Unsupported patch name \"{}\"", x),
             _ => panic!("Unsupported patch."),
         }
     };


### PR DESCRIPTION
Not totally sure about this one. I at least wanted better error reporting on giving a bad option. 

I had considered putting all of the patches into a HashMap where the keys are the patch option and the  values contain the particular VM parametrized by the specific patch. But this would mean creating all of the combinations up front, even though one of them is used. 

A midway approach is to list all of the valid patches in a vector that can be displayed in both help and on error. What do you think? 

