### PR TITLE
Fix a crash when storage_read_orig returns an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 **/result
 tests.bin
 Cargo.lock
+.vscode


### PR DESCRIPTION
When storage_read return an error sputnik will crash
Please avoid using `unwrap` method. 